### PR TITLE
remove inch from hp fortis 14 g11 chromebook

### DIFF
--- a/src/data/cros-updates.json
+++ b/src/data/cros-updates.json
@@ -2585,7 +2585,7 @@
     "Beta": "16033.17.0<br>130.0.6723.25",
     "Dev": "16052.0.0<br>131.0.6752.0",
     "Canary": "16052.0.0<br>131.0.6752.0",
-    "Brand names": "HP Fortis 14 inch G11 Chromebook",
+    "Brand names": "HP Fortis 14 G11 Chromebook",
     "isAue": false
   },
   {


### PR DESCRIPTION
"inch" is not in the name on the back cover of the chromebook !!