### PR TITLE
Add sort for brand names to minimize changes to cros-updates.json

### DIFF
--- a/scripts/scrape.js
+++ b/scripts/scrape.js
@@ -29,7 +29,7 @@ fetch(url, settings)
                 "Dev": formatVersionString(board.servingDev),
                 "Canary": formatVersionString(board.servingCanary),
                 "Recovery": board.pushRecoveries,
-                "Brand names": board.brandNames.join(', '),
+                "Brand names": board.brandNames.sort().join(', '),
                 "isAue": board.isAue,
             }
             return boardObject


### PR DESCRIPTION
Currently the file `cros-updates.json` has [many changes on each commit](https://github.com/skylartaylor/cros-updates/commit/9477cb918f1f03a5ab9f96291cc08c3e1bfc9a77), which only result from a different brand names order if there are more than one, because the source delivers them unordered. This also results in the column "Device Name(s)" on cross.tech to change its content order.

Sorting the brand names alphabetically while creating this file mitigates this.
